### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides web content fetching and local file saving capabilities. This server enables LLMs to retrieve content from web pages, convert HTML to markdown for easier consumption, and save the retrieved content to a local file.
 
+<a href="https://glama.ai/mcp/servers/@gregberns/mcp-server-fetch-save">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gregberns/mcp-server-fetch-save/badge" alt="Fetch-Save Server MCP server" />
+</a>
+
 The key difference from the standard fetch MCP server is that this server provides a **fetch-save** tool that both retrieves content AND stores it locally in a permanent file, allowing for later access or processing of the data.
 
 > [!CAUTION]


### PR DESCRIPTION
This PR adds a badge for the [Fetch-Save MCP Server](https://glama.ai/mcp/servers/@gregberns/mcp-server-fetch-save) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gregberns/mcp-server-fetch-save">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gregberns/mcp-server-fetch-save/badge" alt="Fetch-Save Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.